### PR TITLE
Remove small line height of h5 elements

### DIFF
--- a/themes/hugo-icon/static/css/softwaretalks.css
+++ b/themes/hugo-icon/static/css/softwaretalks.css
@@ -43,7 +43,6 @@ body,html,p,div,h1,h2,h3,h4,h5,h6{
 .fh5co-tabs-container .fh5co-tab-content #next-event h4,
 .fh5co-tabs-container .fh5co-tab-content #next-event h5{ 
   font-weight: 300;
-  line-height: 0.1;
   margin-bottom: 30px;
   color: #7b7b7b;
 }


### PR DESCRIPTION
Fixes #8 and looks good on bigger screens (desktops) too. I think we can remove it as I did. 🙂